### PR TITLE
Use npm GitHub shorthand for GitHub deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
     "url": "https://github.com/mjethani/miniLock-cli.git"
   },
   "dependencies": {
-    "blake2s-js": "git@github.com:dchest/blake2s-js.git#64e449f020c47b88f3edb417efe0fbe65ebdf86e",
-    "bs58": "git@github.com:cryptocoinjs/bs58.git#d3ee704d5f6e9d450333395ba17ce5c654f19d72",
-    "nacl-stream": "git@github.com:dchest/nacl-stream-js.git#cb00b7f06a953ebb7e3895c3a22d6d05208d25a5",
-    "scrypt-async": "git@github.com:dchest/scrypt-async-js.git#ac2e88a22fbb8856ab2f95e85430900f54fec1c9",
-    "tweetnacl": "git@github.com:dchest/tweetnacl-js.git#abfbce7c68c8ad0b3b8a90b769e1f67885237aac",
-    "zxcvbn": "git@github.com:dropbox/zxcvbn.git#063315ee6400116dacbd244f1dc98a54e0c53aec"
+    "blake2s-js": "dchest/blake2s-js.git#64e449f020c47b88f3edb417efe0fbe65ebdf86e",
+    "bs58": "cryptocoinjs/bs58.git#d3ee704d5f6e9d450333395ba17ce5c654f19d72",
+    "nacl-stream": "dchest/nacl-stream-js.git#cb00b7f06a953ebb7e3895c3a22d6d05208d25a5",
+    "scrypt-async": "dchest/scrypt-async-js.git#ac2e88a22fbb8856ab2f95e85430900f54fec1c9",
+    "tweetnacl": "dchest/tweetnacl-js.git#abfbce7c68c8ad0b3b8a90b769e1f67885237aac",
+    "zxcvbn": "dropbox/zxcvbn.git#063315ee6400116dacbd244f1dc98a54e0c53aec"
   },
   "bugs": {
     "url": "https://github.com/mjethani/miniLock-cli/issues",


### PR DESCRIPTION
This allows npm to pick which protocol to use for git clones,
so installing works without an SSH key or a GitHub account.
